### PR TITLE
Fix an invalid flex property and an invalid dependency version

### DIFF
--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -159,7 +159,7 @@ data[data.length] = {
       'selector': '.parent',
       'rules': {
         'display': 'flex',
-        'flex': 'row nowrap',
+        'flex-flow': 'row nowrap',
         'height': '100%',
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "browser-sync": "^2.10.1",
     "gulp": "^3.9.0",
     "gulp-minify-css": "^1.2.2",
-    "gulp-plumber": "/Users/yoksel1.1.0",
+    "gulp-plumber": "^1.1.0",
     "gulp-ruby-sass": "^2.0.6"
   },
   "dependencies": {


### PR DESCRIPTION
`flex: row nowrap` isn't valid a CSS property:

![screen shot 2017-03-26 at 16 23 03](https://cloud.githubusercontent.com/assets/6684554/24332174/45e7a8ec-1242-11e7-862b-507fed39c35f.png)
